### PR TITLE
Fix unicode pattern for price lookup

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def scrape(url: str, headless: bool = True):
                     .evaluate("e => e.nextElementSibling.innerText")
                 )
                 preco_unitario = (
-                    pagina.locator("text=/VALOR UNIT\xc3\x81RIO/i")
+                    pagina.locator("text=/VALOR UNIT\u00c1RIO/i")
                     .nth(0)
                     .evaluate("e => e.nextElementSibling.innerText")
                 )


### PR DESCRIPTION
## Summary
- correct the price lookup text for `VALOR UNITÁRIO`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686aa042ac808332803fa2123ed0063b